### PR TITLE
Add AJAX endpoint for marking requests read and badge updates

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -143,9 +143,24 @@
 
   // Select item
   $doc.on('click', '.wir-item', function () {
+    const $item = $(this);
     $('.wir-item').removeClass('is-active');
-    $(this).addClass('is-active');
-    currentId = parseInt($(this).data('id'), 10);
+    $item.addClass('is-active');
+    currentId = parseInt($item.data('id'), 10);
+    if ($item.hasClass('is-unread')) {
+      $.post(
+        WIRAdmin.ajax,
+        { action: 'wir_mark_read', nonce: WIRAdmin.nonce, request_id: currentId },
+        function (res) {
+          if (res && res.success) {
+            $item.removeClass('is-unread');
+            if (typeof res.data.unread !== 'undefined') {
+              updateUnreadBadge(parseInt(res.data.unread, 10) || 0);
+            }
+          }
+        }
+      );
+    }
     fillPreviewFromServer(currentId);
   });
 

--- a/includes/class-wir-admin.php
+++ b/includes/class-wir-admin.php
@@ -122,51 +122,87 @@ class WIR_Admin {
 		wp_send_json_success( array( 'status' => $next ) );
 	}
 
-	public static function ajax_assign_me() {
-		if ( ! current_user_can( 'edit_wir_requests' ) ) {
-				wp_send_json_error( 'denied', 403 );
-		}
-			check_ajax_referer( 'wir_admin_nonce', 'nonce' );
-			$id  = absint( $_POST['request_id'] ?? 0 );
-			$uid = get_current_user_id();
-			update_post_meta( $id, '_wir_assigned', $uid );
-			$u = get_user_by( 'id', $uid );
-			wp_send_json_success( array( 'name' => $u ? $u->display_name : '' ) );
-	}
+       public static function ajax_assign_me() {
+               if ( ! current_user_can( 'edit_wir_requests' ) ) {
+                               wp_send_json_error( 'denied', 403 );
+               }
+                       check_ajax_referer( 'wir_admin_nonce', 'nonce' );
+                       $id  = absint( $_POST['request_id'] ?? 0 );
+                       $uid = get_current_user_id();
+                       update_post_meta( $id, '_wir_assigned', $uid );
+                       $u = get_user_by( 'id', $uid );
+                       wp_send_json_success( array( 'name' => $u ? $u->display_name : '' ) );
+       }
 
-	private static function render_list_item( $id ) {
-			$pid           = (int) get_post_meta( $id, '_wir_product_id', true );
-			$topic         = get_post_meta( $id, '_wir_topic', true );
-			$name          = get_post_meta( $id, '_wir_name', true );
-			$email         = get_post_meta( $id, '_wir_email', true );
-			$msg           = get_post_field( 'post_content', $id );
-			$status        = get_post_meta( $id, '_wir_status', true ) ?: 'open';
-			$assignee_id   = (int) get_post_meta( $id, '_wir_assigned', true );
-			$assignee_user = $assignee_id ? get_user_by( 'id', $assignee_id ) : null;
-			$assignee_name = $assignee_user ? $assignee_user->display_name : '';
-			$excerpt       = wp_html_excerpt( wp_strip_all_tags( $msg ), 140, '…' );
-			$title         = get_the_title( $pid );
+       public static function ajax_mark_read() {
+               if ( ! current_user_can( 'edit_wir_requests' ) ) {
+                       wp_send_json_error( 'denied', 403 );
+               }
+               check_ajax_referer( 'wir_admin_nonce', 'nonce' );
+               $id = absint( $_POST['request_id'] ?? 0 );
+               if ( ! $id ) {
+                       wp_send_json_error( 'Invalid', 400 );
+               }
+               if ( 'unread' === get_post_meta( $id, '_wir_status', true ) ) {
+                       update_post_meta( $id, '_wir_status', 'open' );
+               }
+               wp_send_json_success( array( 'unread' => self::unread_count() ) );
+       }
 
-			ob_start();
-		?>
-				<div class="wir-item" data-id="<?php echo esc_attr( $id ); ?>" data-name="<?php echo esc_attr( $name ); ?>" data-email="<?php echo esc_attr( $email ); ?>" data-topic="<?php echo esc_attr( $topic ); ?>" data-object-id="<?php echo esc_attr( $pid ); ?>" data-object-title="<?php echo esc_attr( $title ); ?>" data-status="<?php echo esc_attr( $status ); ?>" data-assignee_name="<?php echo esc_attr( $assignee_name ); ?>" data-content="<?php echo esc_attr( wp_strip_all_tags( $msg ) ); ?>">
-						<div class="wir-item-head">
-								<strong class="wir-item-name"><?php echo esc_html( $name ?: __( 'Guest', 'wp-instant-requests' ) ); ?></strong>
-								<span class="wir-item-time"><?php echo esc_html( get_the_date( 'M j, Y H:i', $id ) ); ?></span>
-						</div>
-						<div class="wir-item-sub">
-							<?php if ( $topic ) : ?>
-										<span class="wir-badge"><?php echo esc_html( $topic ); ?></span>
-								<?php endif; ?>
-							<?php if ( $title ) : ?>
-										<span class="wir-dim">· <?php echo esc_html( $title ); ?></span>
-								<?php endif; ?>
-						</div>
-						<div class="wir-item-excerpt"><?php echo esc_html( $excerpt ); ?></div>
-				</div>
-				<?php
-				return ob_get_clean();
-	}
+       private static function render_list_item( $id ) {
+                       $pid           = (int) get_post_meta( $id, '_wir_product_id', true );
+                       $topic         = get_post_meta( $id, '_wir_topic', true );
+                       $name          = get_post_meta( $id, '_wir_name', true );
+                       $email         = get_post_meta( $id, '_wir_email', true );
+                       $msg           = get_post_field( 'post_content', $id );
+                       $status        = get_post_meta( $id, '_wir_status', true ) ?: 'open';
+                       $assignee_id   = (int) get_post_meta( $id, '_wir_assigned', true );
+                       $assignee_user = $assignee_id ? get_user_by( 'id', $assignee_id ) : null;
+                       $assignee_name = $assignee_user ? $assignee_user->display_name : '';
+                       $excerpt       = wp_html_excerpt( wp_strip_all_tags( $msg ), 140, '…' );
+                       $title         = get_the_title( $pid );
+                       $classes       = 'wir-item';
+                       if ( 'unread' === $status ) {
+                               $classes .= ' is-unread';
+                       }
+
+                       ob_start();
+               ?>
+                               <div class="<?php echo esc_attr( $classes ); ?>" data-id="<?php echo esc_attr( $id ); ?>" data-name="<?php echo esc_attr( $name ); ?>" data-email="<?php echo esc_attr( $email ); ?>" data-topic="<?php echo esc_attr( $topic ); ?>" data-object-id="<?php echo esc_attr( $pid ); ?>" data-object-title="<?php echo esc_attr( $title ); ?>" data-status="<?php echo esc_attr( $status ); ?>" data-assignee_name="<?php echo esc_attr( $assignee_name ); ?>" data-content="<?php echo esc_attr( wp_strip_all_tags( $msg ) ); ?>">
+                                               <div class="wir-item-head">
+                                                               <strong class="wir-item-name"><?php echo esc_html( $name ?: __( 'Guest', 'wp-instant-requests' ) ); ?></strong>
+                                                               <span class="wir-item-time"><?php echo esc_html( get_the_date( 'M j, Y H:i', $id ) ); ?></span>
+                                               </div>
+                                               <div class="wir-item-sub">
+                                                       <?php if ( $topic ) : ?>
+                                                                               <span class="wir-badge"><?php echo esc_html( $topic ); ?></span>
+                                                               <?php endif; ?>
+                                                       <?php if ( $title ) : ?>
+                                                                               <span class="wir-dim">· <?php echo esc_html( $title ); ?></span>
+                                                               <?php endif; ?>
+                                               </div>
+                                               <div class="wir-item-excerpt"><?php echo esc_html( $excerpt ); ?></div>
+                               </div>
+                               <?php
+                               return ob_get_clean();
+       }
+
+       private static function unread_count() {
+               $q = new WP_Query(
+                       array(
+                               'post_type'      => WIR_Plugin::CPT,
+                               'post_status'    => 'publish',
+                               'meta_key'       => '_wir_status',
+                               'meta_value'     => 'unread',
+                               'fields'         => 'ids',
+                               'posts_per_page' => 1,
+                               'no_found_rows'  => false,
+                       )
+               );
+               $count = (int) $q->found_posts;
+               wp_reset_postdata();
+               return $count;
+       }
 
 	public static function ajax_check_new() {
 		if ( ! current_user_can( 'edit_wir_requests' ) ) {
@@ -175,49 +211,46 @@ class WIR_Admin {
 			check_ajax_referer( 'wir_admin_nonce', 'nonce' );
 			$last_id = absint( $_POST['last_id'] ?? 0 );
 
-			$q      = new WP_Query(
-				array(
-					'post_type'      => WIR_Plugin::CPT,
-					'posts_per_page' => 20,
-					'orderby'        => 'date',
-					'order'          => 'DESC',
-				)
-			);
-			$items  = array();
-			$max_id = $last_id;
-		while ( $q->have_posts() ) {
-				$q->the_post();
-				$id = get_the_ID();
-			if ( $id > $last_id ) {
-				$items[] = self::render_list_item( $id );
-				if ( $id > $max_id ) {
-						$max_id = $id;
-				}
-			}
-		}
-		wp_reset_postdata();
+               $q      = new WP_Query(
+                               array(
+                                       'post_type'      => WIR_Plugin::CPT,
+                                       'posts_per_page' => 20,
+                                       'orderby'        => 'date',
+                                       'order'          => 'DESC',
+                               )
+                       );
+                       $items  = array();
+                       $max_id = $last_id;
+               while ( $q->have_posts() ) {
+                               $q->the_post();
+                               $id = get_the_ID();
+                       if ( $id > $last_id ) {
+                               if ( 'unread' !== get_post_meta( $id, '_wir_status', true ) ) {
+                                       update_post_meta( $id, '_wir_status', 'unread' );
+                               }
+                               $items[] = self::render_list_item( $id );
+                               if ( $id > $max_id ) {
+                                               $max_id = $id;
+                               }
+                       }
+               }
+               wp_reset_postdata();
 
-		$count  = wp_count_posts( 'wir_request' );
-		$open   = isset( $count->open ) ? (int) $count->open : 0;
-		$seen   = (int) get_option( 'wir_last_seen_open', 0 );
-		$unread = max( 0, $open - $seen );
+               $unread = self::unread_count();
 
-		wp_send_json_success(
-			array(
-				'items'   => $items,
-				'last_id' => $max_id,
-				'unread'  => $unread,
-			)
-		);
-	}
+               wp_send_json_success(
+                       array(
+                               'items'   => $items,
+                               'last_id' => $max_id,
+                               'unread'  => $unread,
+                       )
+               );
+       }
 
 	/** Register menus (Top: Requests; Subs: All Requests, Settings) */
-	public static function menus() {
-		$count  = wp_count_posts( 'wir_request' );
-		$open   = isset( $count->open ) ? (int) $count->open : 0;
-		$seen   = (int) get_option( 'wir_last_seen_open', 0 );
-		$unread = max( 0, $open - $seen );
-		$title  = __( 'Requests', 'wp-instant-requests' );
+       public static function menus() {
+               $unread = self::unread_count();
+               $title  = __( 'Requests', 'wp-instant-requests' );
 
 		if ( $unread > 0 ) {
 			$title .= sprintf(
@@ -275,12 +308,9 @@ class WIR_Admin {
 		self::enqueue_menu_refresh();
 	}
 
-	public static function print_menu_refresh_script() {
-		$count  = wp_count_posts( 'wir_request' );
-		$open   = isset( $count->open ) ? (int) $count->open : 0;
-		$seen   = (int) get_option( 'wir_last_seen_open', 0 );
-		$unread = max( 0, $open - $seen );
-		?>
+       public static function print_menu_refresh_script() {
+               $unread = self::unread_count();
+               ?>
 		<script>
 		(function(){
 			if ( typeof updateUnreadBadge === 'function' ) {
@@ -474,16 +504,22 @@ class WIR_Admin {
 							$excerpt = wp_html_excerpt( wp_strip_all_tags( $msg ), 140, '…' );
 							$title   = get_the_title( $pid );
 							?>
-						<div class="wir-item"
-								data-id="<?php echo esc_attr( get_the_ID() ); ?>"
-								data-name="<?php echo esc_attr( $name ); ?>"
-								data-email="<?php echo esc_attr( $email ); ?>"
-								data-topic="<?php echo esc_attr( $topic ); ?>"
-								data-object-id="<?php echo esc_attr( $pid ); ?>"
-								data-object-title="<?php echo esc_attr( $title ); ?>"
-								data-status="<?php echo esc_attr( $status ); ?>"
-								data-assignee_name="<?php echo esc_attr( $assignee_name ); ?>"
-								data-content="<?php echo esc_attr( wp_strip_all_tags( $msg ) ); ?>">
+                                               <?php
+                                               $classes = 'wir-item';
+                                               if ( 'unread' === $status ) {
+                                                       $classes .= ' is-unread';
+                                               }
+                                               ?>
+                                               <div class="<?php echo esc_attr( $classes ); ?>"
+                                                               data-id="<?php echo esc_attr( get_the_ID() ); ?>"
+                                                               data-name="<?php echo esc_attr( $name ); ?>"
+                                                               data-email="<?php echo esc_attr( $email ); ?>"
+                                                               data-topic="<?php echo esc_attr( $topic ); ?>"
+                                                               data-object-id="<?php echo esc_attr( $pid ); ?>"
+                                                               data-object-title="<?php echo esc_attr( $title ); ?>"
+                                                               data-status="<?php echo esc_attr( $status ); ?>"
+                                                               data-assignee_name="<?php echo esc_attr( $assignee_name ); ?>"
+                                                               data-content="<?php echo esc_attr( wp_strip_all_tags( $msg ) ); ?>">
 							<div class="wir-item-head">
 								<strong class="wir-item-name"><?php echo esc_html( $name ?: __( 'Guest', 'wp-instant-requests' ) ); ?></strong>
 								<span class="wir-item-time"><?php echo esc_html( get_the_date( 'M j, Y H:i' ) ); ?></span>
@@ -871,3 +907,4 @@ class WIR_Admin {
 
 add_action( 'save_post_wir_request', array( WIR_Admin::class, 'refresh_menu_badge' ) );
 add_action( 'transition_post_status', array( WIR_Admin::class, 'transition_menu_badge' ), 10, 3 );
+add_action( 'wp_ajax_wir_mark_read', array( WIR_Admin::class, 'ajax_mark_read' ) );


### PR DESCRIPTION
## Summary
- add `wir_mark_read` AJAX endpoint to convert `_wir_status` from `unread` to `open`
- mark new requests as `unread` in polling and render with `is-unread` class
- update JS click handler to mark items read and refresh menu badge counts

## Testing
- `php -l includes/class-wir-admin.php`
- `node --check assets/js/admin.js`
- `vendor/bin/phpcs --standard=WordPress includes/class-wir-admin.php assets/js/admin.js` *(fails: many existing style violations)*

------
https://chatgpt.com/codex/tasks/task_e_689c91b7dd2483339ba1ac7611044b8c