### PR TITLE
Add pin and star request controls

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -77,12 +77,28 @@
 	border-bottom: 0;
 }
 .wir-item-head {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+}
+.wir-item-head-right {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+}
+.wir-pin,
+.wir-star {
+        color: #9ca3af;
+        cursor: pointer;
+}
+.wir-item.is-pinned .wir-pin {
+        color: #2563eb;
+}
+.wir-item.is-starred .wir-star {
+        color: #d97706;
 }
 .wir-item-name {
-	font-weight: 700;
+        font-weight: 700;
 }
 .wir-item-time {
 	color: #6b7280;


### PR DESCRIPTION
## Summary
- allow requests to be pinned or starred via new AJAX actions and post-meta
- show pin and star icons in list items and sort pinned requests first
- style icons and handle client-side toggling with dynamic list placement

## Testing
- `php -l includes/class-wir-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689c9a4e39388333a75fbe8fab122e9b