### PR TITLE
Make first thread message sticky

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -230,17 +230,23 @@
 	margin: 12px 0;
 }
 .wir-msg {
-	background: #fff;
-	border: 1px solid #e5e7eb;
-	border-radius: 10px;
-	padding: 10px 12px;
-	margin-bottom: 10px;
+        background: #fff;
+        border: 1px solid #e5e7eb;
+        border-radius: 10px;
+        padding: 10px 12px;
+        margin-bottom: 10px;
+}
+.wir-msg.is-first {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background: #f8fafc;
 }
 .wir-msg.is-admin {
-	border-left: 4px solid #2563eb;
+        border-left: 4px solid #2563eb;
 }
 .wir-msg.is-user {
-	border-left: 4px solid #10b981;
+        border-left: 4px solid #10b981;
 }
 .wir-msg-head {
 	font-size: 12px;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -88,13 +88,14 @@
       $t.append('<div class="wir-empty">' + WIRAdmin.i18n.no_messages + '</div>');
       return;
     }
-    items.forEach((m) => {
+    items.forEach((m, i) => {
       const who = m.type === 'out' ? 'admin' : 'user';
       const status = m.status ? '<div class="wir-msg-status">' + m.status + '</div>' : '';
       const ts = m.time ? new Date(m.time * 1000).toLocaleString() : '';
       $t.append(
         '<div class="wir-msg is-' +
           who +
+          (i === 0 ? ' is-first' : '') +
           '">' +
           '<div class="wir-msg-head">' +
           (who === 'admin' ? 'You' : 'User') +


### PR DESCRIPTION
## Summary
- Mark the first message in a thread with an `is-first` class during rendering
- Make the first thread message sticky with a subtle background so it remains fixed while scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9c5acacc8333b19d761911e0bb16