### PR TITLE
Add dashicon icons to status badges and messages

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -113,11 +113,18 @@
 	font-size: 12px;
 }
 .wir-badge {
-	background: #eef2ff;
-	color: #3730a3;
-	border-radius: 999px;
-	padding: 3px 8px;
-	font-weight: 600;
+background: #eef2ff;
+color: #3730a3;
+border-radius: 999px;
+padding: 3px 8px;
+font-weight: 600;
+display: inline-flex;
+align-items: center;
+gap: 4px;
+}
+.wir-badge .dashicons {
+font-size: 16px;
+line-height: 1;
 }
 .wir-status-badge {
 	text-transform: capitalize;
@@ -254,11 +261,17 @@
 	margin-bottom: 4px;
 }
 .wir-msg-body {
-	white-space: pre-wrap;
+white-space: pre-wrap;
+}
+.wir-msg-body .dashicons {
+margin-left: 4px;
+font-size: 16px;
+line-height: 1;
+vertical-align: middle;
 }
 .wir-msg-status {
-	margin-top: 6px;
-	font-size: 12px;
+margin-top: 6px;
+font-size: 12px;
 	color: #6b7280;
 }
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -31,14 +31,18 @@
 
   // Helpers
   function badge(status) {
-    const map = { open: '#2563eb', replied: '#059669', closed: '#6b7280' };
-    const color = map[status] || '#2563eb';
+    const colorMap = { open: '#2563eb', replied: '#059669', closed: '#6b7280' };
+    const iconMap = { open: 'email-alt', replied: 'yes', closed: 'no-alt' };
+    const color = colorMap[status] || '#2563eb';
+    const icon = iconMap[status] || 'email-alt';
     return (
       '<span class="wir-badge" style="background:' +
       color +
       '1a;color:' +
       color +
-      '">' +
+      '"><span class="dashicons dashicons-' +
+      icon +
+      '"></span>' +
       status +
       '</span>'
     );
@@ -92,6 +96,10 @@
       const who = m.type === 'out' ? 'admin' : 'user';
       const status = m.status ? '<div class="wir-msg-status">' + m.status + '</div>' : '';
       const ts = m.time ? new Date(m.time * 1000).toLocaleString() : '';
+      let body = $('<div/>').text(m.message || '').html();
+      if (m.type === 'out') {
+        body += '<span class="dashicons dashicons-email"></span>';
+      }
       $t.append(
         '<div class="wir-msg is-' +
           who +
@@ -103,9 +111,7 @@
           ts +
           '</div>' +
           '<div class="wir-msg-body">' +
-          $('<div/>')
-            .text(m.message || '')
-            .html() +
+          body +
           '</div>' +
           status +
           '</div>'

--- a/includes/class-wir-admin.php
+++ b/includes/class-wir-admin.php
@@ -38,9 +38,31 @@ class WIR_Admin {
 		return is_array( $items ) ? $items : array();
 	}
 
-	private static function save_thread( $id, $items ) {
-		update_post_meta( $id, '_wir_thread', array_values( $items ) );
-	}
+       private static function save_thread( $id, $items ) {
+               update_post_meta( $id, '_wir_thread', array_values( $items ) );
+       }
+
+       private static function render_status_badge( $status ) {
+               $colors = array(
+                       'open'    => '#2563eb',
+                       'replied' => '#059669',
+                       'closed'  => '#6b7280',
+               );
+               $icons  = array(
+                       'open'    => 'email-alt',
+                       'replied' => 'yes',
+                       'closed'  => 'no-alt',
+               );
+               $color  = $colors[ $status ] ?? '#2563eb';
+               $icon   = $icons[ $status ] ?? 'email-alt';
+
+               return sprintf(
+                       '<span class="wir-badge wir-status-badge" style="background:%1$s1a;color:%1$s"><span class="dashicons dashicons-%2$s"></span>%3$s</span>',
+                       esc_attr( $color ),
+                       esc_attr( $icon ),
+                       esc_html( $status )
+               );
+       }
 
 	public static function ajax_get_thread() {
 		check_ajax_referer( 'wir_admin_nonce', 'nonce' );
@@ -222,14 +244,17 @@ class WIR_Admin {
                                                                        <span class="wir-item-time"><?php echo esc_html( get_the_date( 'M j, Y H:i', $id ) ); ?></span>
                                                                </div>
                                                </div>
-                                               <div class="wir-item-sub">
-                                                       <?php if ( $topic ) : ?>
-                                                                               <span class="wir-badge"><?php echo esc_html( $topic ); ?></span>
-                                                               <?php endif; ?>
-                                                       <?php if ( $title ) : ?>
-                                                                               <span class="wir-dim">· <?php echo esc_html( $title ); ?></span>
-                                                               <?php endif; ?>
-                                               </div>
+                                                 <div class="wir-item-sub">
+                                                        <?php if ( $topic ) : ?>
+                                                                                <span class="wir-badge"><?php echo esc_html( $topic ); ?></span>
+                                                        <?php endif; ?>
+                                                        <?php if ( $title ) : ?>
+                                                                                <span class="wir-dim">· <?php echo esc_html( $title ); ?></span>
+                                                        <?php endif; ?>
+                                                        <?php if ( 'open' !== $status ) : ?>
+                                                                                <?php echo self::render_status_badge( $status ); ?>
+                                                        <?php endif; ?>
+                                                 </div>
                                                <div class="wir-item-excerpt"><?php echo esc_html( $excerpt ); ?></div>
                                </div>
                                <?php


### PR DESCRIPTION
## Summary
- prepend dashicon icons to status badges for open, replied, and closed states
- show email icon in outbound admin thread messages
- style badge and thread icons for clearer alignment

## Testing
- `composer install`
- `./vendor/bin/phpcs includes/class-wir-admin.php` *(fails: coding standards issues)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9db7a57083339cf3a9eccf71bd36