### PR TITLE
Mark requests as read when selected

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -178,6 +178,7 @@
       $badge.remove();
     }
   }
+  window.updateUnreadBadge = updateUnreadBadge;
 
   // Select item
   $doc.on('click', '.wir-item', function () {
@@ -185,20 +186,18 @@
     $('.wir-item').removeClass('is-active');
     $item.addClass('is-active');
     currentId = parseInt($item.data('id'), 10);
-    if ($item.hasClass('is-unread')) {
-      $.post(
-        WIRAdmin.ajax,
-        { action: 'wir_mark_read', nonce: WIRAdmin.nonce, request_id: currentId },
-        function (res) {
-          if (res && res.success) {
-            $item.removeClass('is-unread');
-            if (typeof res.data.unread !== 'undefined') {
-              updateUnreadBadge(parseInt(res.data.unread, 10) || 0);
-            }
+    $.post(
+      WIRAdmin.ajax,
+      { action: 'wir_mark_read', nonce: WIRAdmin.nonce, request_id: currentId },
+      function (res) {
+        if (res && res.success) {
+          $item.removeClass('is-unread');
+          if (typeof res.data.unread !== 'undefined') {
+            updateUnreadBadge(parseInt(res.data.unread, 10) || 0);
           }
         }
-      );
-    }
+      }
+    );
     fillPreviewFromServer(currentId);
   });
 

--- a/includes/class-wir-admin.php
+++ b/includes/class-wir-admin.php
@@ -158,12 +158,12 @@ class WIR_Admin {
 
        public static function ajax_mark_read() {
                if ( ! current_user_can( 'edit_wir_requests' ) ) {
-                       wp_send_json_error( 'denied', 403 );
+                       wp_send_json_error( __( 'Permission denied.', 'wp-instant-requests' ), 403 );
                }
                check_ajax_referer( 'wir_admin_nonce', 'nonce' );
                $id = absint( $_POST['request_id'] ?? 0 );
                if ( ! $id ) {
-                       wp_send_json_error( 'Invalid', 400 );
+                       wp_send_json_error( __( 'Invalid request.', 'wp-instant-requests' ), 400 );
                }
                if ( 'unread' === get_post_meta( $id, '_wir_status', true ) ) {
                        update_post_meta( $id, '_wir_status', 'open' );


### PR DESCRIPTION
## Summary
- Trigger AJAX call on request selection to mark items as read and update unread menu badge
- Expose `updateUnreadBadge` globally and improve read status handling
- Localize permission and invalid request messages in read-status endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_689bac91105083339978d00e541d7a63