### PR TITLE
Expose badge utilities globally and unify polling

### DIFF
--- a/assets/js/admin-badge.js
+++ b/assets/js/admin-badge.js
@@ -26,8 +26,8 @@
     }
   }
 
-  // Insert an item into the list while keeping pinned at the top (same logic as admin.js)
-  function placeItem($item) {
+    // Insert an item into the list while keeping pinned at the top (same logic as admin.js)
+    function placeItem($item) {
     const $list = $('.wir-list-inner');
     if (!$list.length) return; // not on the mailbox page
     const time = parseInt($item.data('time'), 10) || 0;
@@ -35,7 +35,8 @@
       $list.prepend($item);
       return;
     }
-    let inserted = false;
+
+      let inserted = false;
     const $unpinned = $list.children('.wir-item').not('.is-pinned');
     $unpinned.each(function () {
       const t = parseInt($(this).data('time'), 10) || 0;
@@ -45,14 +46,18 @@
         return false;
       }
     });
-    if (!inserted) {
-      const $lastPinned = $list.children('.wir-item.is-pinned').last();
-      if ($lastPinned.length) $lastPinned.after($item);
-      else $list.append($item);
+      if (!inserted) {
+        const $lastPinned = $list.children('.wir-item.is-pinned').last();
+        if ($lastPinned.length) $lastPinned.after($item);
+        else $list.append($item);
+      }
     }
-  }
 
-  function scanInitialMaxId() {
+    // Expose utilities globally for admin.js
+    window.updateUnreadBadge = updateUnreadBadge;
+    window.placeItem = placeItem;
+
+    function scanInitialMaxId() {
     const ids = $('.wir-item')
       .map(function () {
         return parseInt($(this).data('id'), 10) || 0;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -3,7 +3,6 @@
   'use strict';
   const $doc = $(document);
   let currentId = 0;
-  let lastKnownId = 0;
 
   // Set mailbox height based on available viewport space
   function setMailboxHeightVar() {
@@ -15,17 +14,9 @@
     grid.style.height = h + 'px';
   }
 
-  document.addEventListener('DOMContentLoaded', function () {
-    setMailboxHeightVar();
-    const ids = $('.wir-item')
-      .map(function () {
-        return parseInt($(this).data('id'), 10) || 0;
-      })
-      .get();
-    if (ids.length) {
-      lastKnownId = Math.max.apply(null, ids);
-    }
-  });
+    document.addEventListener('DOMContentLoaded', function () {
+      setMailboxHeightVar();
+    });
   window.addEventListener('resize', setMailboxHeightVar);
 
   // Helpers
@@ -58,32 +49,7 @@
     }
   }
 
-  function placeItem($item) {
-    const $list = $('.wir-list-inner');
-    const time = parseInt($item.data('time'), 10) || 0;
-    if ($item.hasClass('is-pinned')) {
-      $list.prepend($item);
-      return;
-    }
-    let inserted = false;
-    const $unpinned = $list.children('.wir-item').not('.is-pinned');
-    $unpinned.each(function () {
-      const t = parseInt($(this).data('time'), 10) || 0;
-      if (!inserted && time > t) {
-        $(this).before($item);
-        inserted = true;
-        return false;
-      }
-    });
-    if (!inserted) {
-      const $lastPinned = $list.children('.wir-item.is-pinned').last();
-      if ($lastPinned.length) {
-        $lastPinned.after($item);
-      } else {
-        $list.append($item);
-      }
-    }
-  }
+    // placeItem is provided by admin-badge.js
 
   function renderThread(items) {
     const $t = $('.wir-thread').empty();
@@ -158,28 +124,7 @@
     );
   }
 
-  function updateUnreadBadge(count) {
-    const $menu = $('#toplevel_page_wir .wp-menu-name');
-    let $badge = $menu.find('.update-plugins');
-    if (count > 0) {
-      if (!$badge.length) {
-        $badge = $(
-          '<span class="update-plugins count-' +
-            count +
-            '"><span class="plugin-count">' +
-            count +
-            '</span></span>'
-        );
-        $menu.append($badge);
-      } else {
-        $badge.attr('class', 'update-plugins count-' + count);
-        $badge.find('.plugin-count').text(count);
-      }
-    } else {
-      $badge.remove();
-    }
-  }
-  window.updateUnreadBadge = updateUnreadBadge;
+  // updateUnreadBadge is provided by admin-badge.js
 
   // Select item
   $doc.on('click', '.wir-item', function () {
@@ -312,27 +257,7 @@
     });
   });
 
-  // Poll for new requests
-  setInterval(function () {
-    $.post(
-      WIRAdmin.ajax,
-      { action: 'wir_check_new', nonce: WIRAdmin.nonce, last_id: lastKnownId },
-      function (res) {
-        if (res && res.success) {
-          if (Array.isArray(res.data.items) && res.data.items.length) {
-            res.data.items.forEach(function (html) {
-              const $item = $(html);
-              placeItem($item);
-            });
-            lastKnownId = parseInt(res.data.last_id, 10) || lastKnownId;
-          }
-          if (typeof res.data.unread !== 'undefined') {
-            updateUnreadBadge(parseInt(res.data.unread, 10) || 0);
-          }
-        }
-      }
-    );
-  }, 15000);
+  // Polling handled by admin-badge.js
 
   // Toggle status
   $doc.on('click', '#wir-toggle-status', function (e) {

--- a/includes/class-wir-admin.php
+++ b/includes/class-wir-admin.php
@@ -438,7 +438,7 @@ class WIR_Admin {
 		}
 
 		wp_enqueue_style( 'wir-admin', WIR_URL . 'assets/css/admin.css', array(), WIR_VERSION );
-		wp_enqueue_script( 'wir-admin', WIR_URL . 'assets/js/admin.js', array( 'jquery' ), WIR_VERSION, true );
+               wp_enqueue_script( 'wir-admin', WIR_URL . 'assets/js/admin.js', array( 'jquery', 'wir-admin-badge' ), WIR_VERSION, true );
 
 		wp_localize_script(
 			'wir-admin',


### PR DESCRIPTION
## Summary
- remove unread badge helper and polling interval from `admin.js`
- export `updateUnreadBadge` and `placeItem` globals in `admin-badge.js`
- enqueue `admin-badge.js` everywhere and load before `admin.js`

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=WordPress includes/class-wir-admin.php` *(fails: numerous pre-existing coding standard issues)*

------
https://chatgpt.com/codex/tasks/task_e_689cc059d95883339c40027501f3779b