### PR TITLE
Persist admin last seen ID for request polling

### DIFF
--- a/assets/js/admin-badge.js
+++ b/assets/js/admin-badge.js
@@ -1,6 +1,6 @@
 (function ($) {
   'use strict';
-  let lastKnownId = 0;
+  let lastKnownId = parseInt(WIRBadge.last_id, 10) || 0;
 
   // Update the admin menu badge (works on any admin page)
   function updateUnreadBadge(count) {
@@ -63,7 +63,10 @@
         return parseInt($(this).data('id'), 10) || 0;
       })
       .get();
-    if (ids.length) lastKnownId = Math.max.apply(null, ids);
+    if (ids.length) {
+      const domMax = Math.max.apply(null, ids);
+      if (domMax > lastKnownId) lastKnownId = domMax;
+    }
   }
 
   function poll() {


### PR DESCRIPTION
## Summary
- Only flag requests created after the last poll as unread and persist each admin's last seen request ID
- Localize last seen ID to admin-badge script and initialize polling with it
- Preserve existing unread counts without altering older request statuses

## Testing
- `php -l includes/class-wir-admin.php`
- `node --check assets/js/admin-badge.js`
- `vendor/bin/phpcs --standard=WordPress includes/class-wir-admin.php assets/js/admin-badge.js | head -n 20` *(fails: Missing doc comments and coding standards warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689cc96da1248333a400c691f862abf3