### PR TITLE
Use "unread" status for new requests

### DIFF
--- a/includes/class-wir-admin.php
+++ b/includes/class-wir-admin.php
@@ -304,12 +304,9 @@ class WIR_Admin {
 	                        $max_id = $id;
 	                }
 
-	                if ( $last_id && $id > $last_id ) {
-	                        if ( 'unread' !== get_post_meta( $id, '_wir_status', true ) ) {
-	                                update_post_meta( $id, '_wir_status', 'unread' );
-	                        }
-	                        $items[] = self::render_list_item( $id );
-	                }
+                       if ( $last_id && $id > $last_id ) {
+                               $items[] = self::render_list_item( $id );
+                       }
 	        }
 
 	        wp_reset_postdata();

--- a/includes/class-wir-ajax.php
+++ b/includes/class-wir-ajax.php
@@ -57,7 +57,7 @@ class WIR_Ajax {
 				),
 			)
 		);
-		update_post_meta( $post_id, '_wir_status', 'open' );
+               update_post_meta( $post_id, '_wir_status', 'unread' );
 
 		// Optional email notify.
 		$o = WIR_Plugin::settings();


### PR DESCRIPTION
## Summary
- mark newly created requests as `unread`
- drop redundant status correction in `ajax_check_new`

## Testing
- `php -l includes/class-wir-ajax.php includes/class-wir-admin.php`
- `vendor/bin/phpcs includes/class-wir-ajax.php includes/class-wir-admin.php` *(fails: numerous existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_689ccb73fd5883338f67a034c716feaa