### PR TITLE
refactor: centralize admin utilities

### DIFF
--- a/assets/js/admin-badge.js
+++ b/assets/js/admin-badge.js
@@ -1,61 +1,9 @@
+
 (function ($) {
   'use strict';
+  // Shared utilities
+  const { updateUnreadBadge, placeItem } = window.WIRUtils;
   let lastKnownId = parseInt(WIRBadge.last_id, 10) || 0;
-
-  // Update the admin menu badge (works on any admin page)
-  function updateUnreadBadge(count) {
-    const $menu = $('#toplevel_page_wir .wp-menu-name');
-    if (!$menu.length) return;
-    let $badge = $menu.find('.update-plugins');
-    if (count > 0) {
-      if (!$badge.length) {
-        $badge = $(
-          '<span class="update-plugins count-' +
-            count +
-            '"><span class="plugin-count">' +
-            count +
-            '</span></span>'
-        );
-        $menu.append($badge);
-      } else {
-        $badge.attr('class', 'update-plugins count-' + count);
-        $badge.find('.plugin-count').text(count);
-      }
-    } else if ($badge.length) {
-      $badge.remove();
-    }
-  }
-
-    // Insert an item into the list while keeping pinned at the top (same logic as admin.js)
-    function placeItem($item) {
-    const $list = $('.wir-list-inner');
-    if (!$list.length) return; // not on the mailbox page
-    const time = parseInt($item.data('time'), 10) || 0;
-    if ($item.hasClass('is-pinned')) {
-      $list.prepend($item);
-      return;
-    }
-
-      let inserted = false;
-    const $unpinned = $list.children('.wir-item').not('.is-pinned');
-    $unpinned.each(function () {
-      const t = parseInt($(this).data('time'), 10) || 0;
-      if (!inserted && time > t) {
-        $(this).before($item);
-        inserted = true;
-        return false;
-      }
-    });
-      if (!inserted) {
-        const $lastPinned = $list.children('.wir-item.is-pinned').last();
-        if ($lastPinned.length) $lastPinned.after($item);
-        else $list.append($item);
-      }
-    }
-
-    // Expose utilities globally for admin.js
-    window.updateUnreadBadge = updateUnreadBadge;
-    window.placeItem = placeItem;
 
     function scanInitialMaxId() {
     const ids = $('.wir-item')

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,6 +1,7 @@
 /* global jQuery, WIRAdmin */
 (function ($) {
   'use strict';
+  const { updateUnreadBadge, placeItem } = window.WIRUtils;
   const $doc = $(document);
   let currentId = 0;
 
@@ -49,7 +50,7 @@
     }
   }
 
-    // placeItem is provided by admin-badge.js
+  // placeItem is provided by WIRUtils
 
   function renderThread(items) {
     const $t = $('.wir-thread').empty();
@@ -124,7 +125,7 @@
     );
   }
 
-  // updateUnreadBadge is provided by admin-badge.js
+  // updateUnreadBadge is provided by WIRUtils
 
   // Select item
   $doc.on('click', '.wir-item', function () {

--- a/assets/js/wir-utils.js
+++ b/assets/js/wir-utils.js
@@ -1,0 +1,57 @@
+(function ($) {
+  'use strict';
+
+  function updateUnreadBadge(count) {
+    const $menu = $('#toplevel_page_wir .wp-menu-name');
+    if (!$menu.length) return;
+    let $badge = $menu.find('.update-plugins');
+    if (count > 0) {
+      if (!$badge.length) {
+        $badge = (
+          '<span class="update-plugins count-' +
+          count +
+          '"><span class="plugin-count">' +
+          count +
+          '</span></span>'
+        );
+        $menu.append($badge);
+      } else {
+        $badge.attr('class', 'update-plugins count-' + count);
+        $badge.find('.plugin-count').text(count);
+      }
+    } else if ($badge.length) {
+      $badge.remove();
+    }
+  }
+
+  function placeItem($item) {
+    const $list = $('.wir-list-inner');
+    if (!$list.length) return;
+    const time = parseInt($item.data('time'), 10) || 0;
+    if ($item.hasClass('is-pinned')) {
+      $list.prepend($item);
+      return;
+    }
+
+    let inserted = false;
+    const $unpinned = $list.children('.wir-item').not('.is-pinned');
+    $unpinned.each(function () {
+      const t = parseInt($(this).data('time'), 10) || 0;
+      if (!inserted && time > t) {
+        $(this).before($item);
+        inserted = true;
+        return false;
+      }
+    });
+    if (!inserted) {
+      const $lastPinned = $list.children('.wir-item.is-pinned').last();
+      if ($lastPinned.length) $lastPinned.after($item);
+      else $list.append($item);
+    }
+  }
+
+  window.WIRUtils = {
+    updateUnreadBadge: updateUnreadBadge,
+    placeItem: placeItem,
+  };
+})(jQuery);

--- a/includes/class-wir-admin.php
+++ b/includes/class-wir-admin.php
@@ -438,7 +438,8 @@ class WIR_Admin {
 
 	/** Load CSS/JS only on our pages */
 	public static function enqueue_admin_assets() {
-	        wp_enqueue_script( 'wir-admin-badge', WIR_URL . 'assets/js/admin-badge.js', array( 'jquery' ), WIR_VERSION, true );
+		wp_enqueue_script( 'wir-utils', WIR_URL . 'assets/js/wir-utils.js', array( 'jquery' ), WIR_VERSION, true );
+		wp_enqueue_script( 'wir-admin-badge', WIR_URL . 'assets/js/admin-badge.js', array( 'jquery', 'wir-utils' ), WIR_VERSION, true );
 
 	        $uid       = get_current_user_id();
 	        $last_seen = $uid ? (int) get_user_meta( $uid, '_wir_last_seen_id', true ) : 0;
@@ -459,7 +460,7 @@ class WIR_Admin {
 		}
 
 		wp_enqueue_style( 'wir-admin', WIR_URL . 'assets/css/admin.css', array(), WIR_VERSION );
-	       wp_enqueue_script( 'wir-admin', WIR_URL . 'assets/js/admin.js', array( 'jquery', 'wir-admin-badge' ), WIR_VERSION, true );
+		wp_enqueue_script( 'wir-admin', WIR_URL . 'assets/js/admin.js', array( 'jquery', 'wir-utils', 'wir-admin-badge' ), WIR_VERSION, true );
 
 		wp_localize_script(
 			'wir-admin',


### PR DESCRIPTION
## Summary
- add `wir-utils.js` with shared `updateUnreadBadge` and `placeItem` helpers
- consume these utilities from `admin.js` and `admin-badge.js`
- enqueue the new utility module in admin asset loader

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=WordPress includes/class-wir-admin.php` *(fails: unslashed input / coding standard warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689ce08808bc8333a5045f235353357d