### PR TITLE
Optimize new request polling and queries

### DIFF
--- a/assets/js/admin-badge.js
+++ b/assets/js/admin-badge.js
@@ -46,6 +46,7 @@
 
   document.addEventListener('DOMContentLoaded', function () {
     scanInitialMaxId();
+    poll();
     setInterval(poll, 15000);
   });
 })(jQuery);

--- a/includes/class-wir-admin.php
+++ b/includes/class-wir-admin.php
@@ -362,26 +362,28 @@ class WIR_Admin {
 		check_ajax_referer( 'wir_admin_nonce', 'nonce' );
 
 		$last_id = absint( $_POST['last_id'] ?? 0 );
-
+		
+		// If there's no last seen ID, skip querying posts and just return unread count.
+		if ( ! $last_id ) {
+		$unread = self::unread_count();
+		wp_send_json_success( array( 'unread' => $unread ) );
+		}
+		
 		$args = array(
-			'post_type'      => WIR_Plugin::CPT,
-			'posts_per_page' => -1,
-			'orderby'        => 'ID',
-			'order'          => 'ASC',
+		'post_type'      => WIR_Plugin::CPT,
+		'posts_per_page' => 50,
+		'orderby'        => 'ID',
+		'order'          => 'ASC',
 		);
-
-		if ( $last_id ) {
-			add_filter( 'posts_where', $where_filter = function ( $where ) use ( $last_id ) {
-				global $wpdb;
-				return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d", $last_id );
-			});
-		}
-
+		
+		add_filter( 'posts_where', $where_filter = function ( $where ) use ( $last_id ) {
+		global $wpdb;
+		return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d", $last_id );
+		} );
+		
 		$q = new WP_Query( $args );
-
-		if ( $last_id ) {
-			remove_filter( 'posts_where', $where_filter );
-		}
+		
+		remove_filter( 'posts_where', $where_filter );
 
 		$items  = array();
 		$max_id = $last_id;


### PR DESCRIPTION
## Summary
- Skip heavy query when no last seen ID and only return unread count
- Limit new request checks to 50 posts and filter by ID
- Trigger initial badge poll on load to send stored last seen ID

## Testing
- `composer install`
- `vendor/bin/phpcs includes/class-wir-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_689cf335f2a08333a8f94871b3577bd8