### PR TITLE
Add honeypot field and submission throttling

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -12,6 +12,7 @@
     el('wir-message').value = '';
     el('wir-gdpr').checked = false;
     el('wir-status').textContent = '';
+    if (el('wir-hp')) el('wir-hp').value = '';
     el('wir-modal').style.display = 'flex';
     el('wir-backdrop').style.display = 'block';
   }
@@ -78,6 +79,7 @@
       topic: el('wir-topic').value,
       message: el('wir-message').value.trim(),
       gdpr: el('wir-gdpr').checked ? '1' : '0',
+      hp: el('wir-hp') ? el('wir-hp').value.trim() : '',
     };
     if (!data.name || !data.email || !data.message) {
       status.textContent = WIRData.i18n_required || 'Please fill required fields.';

--- a/includes/class-wir-ajax.php
+++ b/includes/class-wir-ajax.php
@@ -6,12 +6,24 @@ class WIR_Ajax {
 	public static function submit() {
 		check_ajax_referer( WIR_Plugin::NONCE, 'nonce' );
 
-		$pid   = isset( $_POST['pid'] ) ? absint( $_POST['pid'] ) : 0;
-		$name  = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
-		$email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
-		$topic = isset( $_POST['topic'] ) ? sanitize_text_field( wp_unslash( $_POST['topic'] ) ) : '';
-		$msg   = isset( $_POST['message'] ) ? wp_kses_post( wp_unslash( $_POST['message'] ) ) : '';
-		$gdpr  = isset( $_POST['gdpr'] ) && $_POST['gdpr'] === '1';
+                $pid   = isset( $_POST['pid'] ) ? absint( $_POST['pid'] ) : 0;
+                $name  = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+                $email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
+                $topic = isset( $_POST['topic'] ) ? sanitize_text_field( wp_unslash( $_POST['topic'] ) ) : '';
+                $msg   = isset( $_POST['message'] ) ? wp_kses_post( wp_unslash( $_POST['message'] ) ) : '';
+                $gdpr  = isset( $_POST['gdpr'] ) && $_POST['gdpr'] === '1';
+                $hp    = isset( $_POST['hp'] ) ? trim( wp_unslash( $_POST['hp'] ) ) : '';
+                $uid   = get_current_user_id();
+                $remote_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+                $tkey  = 'wir_t_' . ( $uid ? $uid : md5( $remote_ip ) );
+
+                if ( $hp !== '' ) {
+                        wp_send_json_error( __( 'Spam detected.', 'wp-instant-requests' ), 400 );
+                }
+
+                if ( get_transient( $tkey ) ) {
+                        wp_send_json_error( __( 'Please wait before sending another request.', 'wp-instant-requests' ), 429 );
+                }
 
 		if ( ! $name || ! $email || ! is_email( $email ) || ! $msg ) {
 			wp_send_json_error( __( 'Missing or invalid fields.', 'wp-instant-requests' ), 400 );
@@ -67,18 +79,17 @@ class WIR_Ajax {
 			if ( ! $token ) {
 				wp_send_json_error( __( 'Captcha missing.', 'wp-instant-requests' ), 400 );
 			}
-			$remote_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-			$resp      = wp_safe_remote_post(
-				'https://www.google.com/recaptcha/api/siteverify',
-				array(
-					'timeout' => 8,
-					'body'    => array(
-						'secret'   => $o['recaptcha_secret'],
-						'response' => $token,
-						'remoteip' => $remote_ip,
-					),
-				)
-			);
+                        $resp      = wp_safe_remote_post(
+                                'https://www.google.com/recaptcha/api/siteverify',
+                                array(
+                                        'timeout' => 8,
+                                        'body'    => array(
+                                                'secret'   => $o['recaptcha_secret'],
+                                                'response' => $token,
+                                                'remoteip' => $remote_ip,
+                                        ),
+                                )
+                        );
 			$ok        = false;
 			if ( ! is_wp_error( $resp ) ) {
 				$body = json_decode( wp_remote_retrieve_body( $resp ), true );
@@ -104,18 +115,20 @@ class WIR_Ajax {
 			wp_mail( $to, $subject, $body );
 		}
 
-		do_action(
-			'wir_request_created',
-			$post_id,
-			array(
-				'name'       => $name,
-				'email'      => $email,
+                set_transient( $tkey, 1, MINUTE_IN_SECONDS );
+
+                do_action(
+                        'wir_request_created',
+                        $post_id,
+                        array(
+                                'name'       => $name,
+                                'email'      => $email,
 				'topic'      => $topic,
 				'product_id' => $pid,
 				'message'    => wp_strip_all_tags( $msg ),
 			)
 		);
 
-		wp_send_json_success( array( 'id' => $post_id ) );
-	}
+                wp_send_json_success( array( 'id' => $post_id ) );
+        }
 }

--- a/includes/class-wir-assets.php
+++ b/includes/class-wir-assets.php
@@ -119,13 +119,15 @@ class WIR_Assets {
 				<label class="wir-label" style="margin-top:10px;"><?php esc_html_e( 'Topic', 'wp-instant-requests' ); ?></label>
 				<select class="wir-select" id="wir-topic"></select>
 
-				<label class="wir-label" style="margin-top:10px;"><?php esc_html_e( 'Message', 'wp-instant-requests' ); ?></label>
-				<textarea class="wir-textarea" id="wir-message" rows="5" maxlength="2000" placeholder="<?php esc_attr_e( 'Type your question or request…', 'wp-instant-requests' ); ?>"></textarea>
+                               <label class="wir-label" style="margin-top:10px;"><?php esc_html_e( 'Message', 'wp-instant-requests' ); ?></label>
+                               <textarea class="wir-textarea" id="wir-message" rows="5" maxlength="2000" placeholder="<?php esc_attr_e( 'Type your question or request…', 'wp-instant-requests' ); ?>"></textarea>
 
-				<label style="display:flex;gap:8px;align-items:flex-start;margin-top:10px;">
-					<input type="checkbox" id="wir-gdpr" />
-					<span id="wir-gdpr-label"><?php echo esc_html( $o['gdpr_label'] ?? '' ); ?></span>
-				</label>
+                               <input type="text" id="wir-hp" autocomplete="off" tabindex="-1" style="display:none" aria-hidden="true" />
+
+                               <label style="display:flex;gap:8px;align-items:flex-start;margin-top:10px;">
+                                        <input type="checkbox" id="wir-gdpr" />
+                                        <span id="wir-gdpr-label"><?php echo esc_html( $o['gdpr_label'] ?? '' ); ?></span>
+                               </label>
 
 				<div class="wir-actions">
 					<button class="wir-btn wir-btn-secondary" id="wir-cancel"><?php esc_html_e( 'Cancel', 'wp-instant-requests' ); ?></button>


### PR DESCRIPTION
## Summary
- Add hidden honeypot field to modal and frontend script to deter bots
- Reject form submissions filling the honeypot and throttle repeat attempts by user or IP

## Testing
- `composer install`
- `./vendor/bin/phpcs --standard=WordPress --runtime-set ignore_warnings_on_exit 1 includes/class-wir-assets.php includes/class-wir-ajax.php` *(fails: many existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_689cf9c8c854833384db3d1ad8e5658d